### PR TITLE
Add a current label

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Label|Description|Color|Example
 blocked|Work blocked by something else|`#CC0000` (crimson)|<img width="67" alt="label-blocked" src="https://user-images.githubusercontent.com/138944/76612724-c8c00480-6514-11ea-9dee-5e2344d31864.png">
 breaking|Will require a major version bump|`#990F3D` (claret)|<img width="72" alt="label-breaking" src="https://user-images.githubusercontent.com/138944/76612740-d7a6b700-6514-11ea-9cb2-ecccfa30dc6b.png">
 bug|Something isn't working|`#CC0000` (crimson)|<img width="41" alt="label-bug" src="https://user-images.githubusercontent.com/138944/76612741-d7a6b700-6514-11ea-885a-567d110b9e84.png">
+current|Used to mark an issue as planned for Origami's current six-week cycle|`#FFB885` (mandarin 60% on white)|<img width="62" alt="label-current" src="https://user-images.githubusercontent.com/138944/78148389-b9095100-742c-11ea-9ae7-32571eb0a01b.png">
 dependencies|This is maintenance work relating to dependency bumps|`#FFEC1A` (lemon)|<img width="106" alt="label-dependencies" src="https://user-images.githubusercontent.com/138944/76756794-4fc3e580-677e-11ea-9364-c16c3231e3e4.png">
 discussion|General discussion including support questions|`#FF7FAA` (candy)|<img width="84" alt="label-discussion" src="https://user-images.githubusercontent.com/138944/76612742-d83f4d80-6514-11ea-9a2e-1d4b3b3eec8d.png">
 documentation|Improvements or additions to documentation|`#CCE6FF` (sky)|<img width="113" alt="label-documentation" src="https://user-images.githubusercontent.com/138944/76612743-d83f4d80-6514-11ea-8d29-cb9ef62751cf.png">

--- a/labels.js
+++ b/labels.js
@@ -9,6 +9,7 @@ const colors = {
 	jade: '00994d',
 	lemon: 'ffec1a',
 	oxford: '0f5499',
+	mandarinWhite60: 'ffb885',
 	sky: 'cce6ff',
 	slate: '262a33',
 	teal: '0d7680',
@@ -117,6 +118,12 @@ module.exports = [
 		aliases: [
 			'status: help wanted'
 		]
+	},
+	{
+		name: `current`,
+		description: `Used to mark an issue as planned for Origami's current six-week cycle`,
+		color: colors.mandarinWhite60,
+		aliases: []
 	},
 	{
 		name: 'maintenance',


### PR DESCRIPTION
This will be used to mark an issue as planned for Origami's next
six-week cycle. This will help us keep track of what we need to cover in
planning sessions, and also give us an easy way to find the issues and
pull requests with the highest priority.

<img width="62" alt="label-current" src="https://user-images.githubusercontent.com/138944/78148389-b9095100-742c-11ea-9ae7-32571eb0a01b.png">
