### PR TITLE
Allow arbitrary labels to be added

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const labels = require('./labels');
 void async function () {
 	try {
 		await githubLabelSync({
+			allowAddedLabels: true,
 			accessToken: core.getInput('github-token'),
 			repo: process.env.GITHUB_REPOSITORY,
 			labels,


### PR DESCRIPTION
We want to be able to track things related to specific OKRs or ad-hoc plans. 
Milestones are great for this, but an issue can only be in one of those.
This way we can create labels on the fly, and we can remove them by hand once they're no longer valuable.

The githubLabelSync is great for making sure we have the minimum labels across our repos, but we it shouldn't be enforcing a maximum.

closes #39 