### PR TITLE
Add release:beta label

### DIFF
--- a/labels.js
+++ b/labels.js
@@ -223,6 +223,12 @@ module.exports = [
 		description: `Add to a PR to trigger a PATCH version bump when merged`,
 		color: colors.sky,
 		aliases: []
+	},
+	{
+		name: 'release:beta',
+		description: `Add to a PR to trigger a PRERELEASE version bump when merged`,
+		color: colors.candy,
+		aliases: []
 	}
 
 ];


### PR DESCRIPTION
This label can be used with the [origami-version](https://github.com/Financial-Times/origami-version/releases/tag/v1.2.0) action to automatically release a PRERELEASE version of the project